### PR TITLE
docs(examples): fix DHL argparse help copy-pasted from meta-learning

### DIFF
--- a/examples/data_hyper_cleaning/data_hyper_cleaning.py
+++ b/examples/data_hyper_cleaning/data_hyper_cleaning.py
@@ -59,19 +59,30 @@ def main():
         "--gm_op",
         type=str,
         default=None,
-        help="omniglot or miniimagenet or tieredImagenet",
+        help=(
+            "Comma-separated Gradient Mapping operators applied to the lower "
+            "level dynamical system (e.g. NGD, DI, GDA, DM, RGT). See "
+            "boat_torch/gm_ol/ for the full list."
+        ),
     )
     parser.add_argument(
         "--na_op",
         type=str,
         default=None,
-        help="convnet for 4 convs or resnet for Residual blocks",
+        help=(
+            "Comma-separated Numerical Approximation operators used to compute "
+            "the hyper-gradient (e.g. CG, FD, RAD, IAD, IGA, NS, PTT, RGT, "
+            "FOA). See boat_torch/na_ol/ for the full list."
+        ),
     )
     parser.add_argument(
         "--fo_op",
         type=str,
         default=None,
-        help="convnet for 4 convs or resnet for Residual blocks",
+        help=(
+            "First-Order operator selected for the bilevel update (e.g. MESO, "
+            "PGDO, VFO, VSO). See boat_torch/fo_ol/ for the full list."
+        ),
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Description

The `--gm_op`, `--na_op`, and `--fo_op` flags in `examples/data_hyper_cleaning/data_hyper_cleaning.py` (lines 58-75) advertised `omniglot or miniimagenet or tieredImagenet` and `convnet for 4 convs or resnet for Residual blocks`. Those values belong to the meta-learning example: data hyper-cleaning does not consume datasets or backbones, it composes GM/NA/FO operators.

The result was that a new user running `python data_hyper_cleaning.py --help` to learn the legal values for these flags was directed to incorrect names. Reported in [#24](https://github.com/callous-youth/BOAT/issues/24).

This PR replaces the help strings with the operator names actually accepted by each flag, derived from the modules under `boat_torch/gm_ol/`, `boat_torch/na_ol/`, and `boat_torch/fo_ol/`, and points readers at those directories for the authoritative list. No runtime behaviour changes.

Closes #24

## Types of Changes

- [x] Fix / Optimization (performance improvement or bug fix)
- [ ] New Feature (e.g., adding a new atomic operation for GM, NA, or FO)
- [x] Documentation / Example Update
- [ ] Breaking Change (causes changes to existing functionality)

## Pre-Submission Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/callous-youth/BOAT/blob/main/CONTRIBUTING.md) guide.
- [x] The code has been formatted using `black` (only the touched hunks; pre-existing whitespace nits in unrelated lines were left untouched to keep the diff scoped).
- [ ] (If applicable) I have updated the relevant Sphinx documentation.