### PR TITLE
fix(tests): use relative path in test_data_hyper_cleaning (fixes #28)

### DIFF
--- a/examples/data_hyper_cleaning/test_data_hyper_cleaning.py
+++ b/examples/data_hyper_cleaning/test_data_hyper_cleaning.py
@@ -1,6 +1,9 @@
+import os
 import pytest
 import subprocess
 from unittest.mock import patch
+
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), "data_hyper_cleaning.py")
 
 gm_oplist = (
     ["NGD"],
@@ -39,7 +42,7 @@ fo_ol_method = (["VSO"], ["VFO"], ["MESO"], ["PGDO"])
 def test_combination_dynamic_na_op(gm_op, na_op):
     command = [
         "python",
-        "/home/runner/work/BOAT/BOAT/examples/data_hyper_cleaning/data_hyper_cleaning.py",
+        SCRIPT_PATH,
         "--gm_op",
         ",".join(gm_op),
         "--na_op",
@@ -67,7 +70,7 @@ def test_combination_dynamic_na_op(gm_op, na_op):
 def test_combination_dynamic_na_op_dm(gm_op, na_op):
     command = [
         "python",
-        "/home/runner/work/BOAT/BOAT/examples/data_hyper_cleaning/data_hyper_cleaning.py",
+        SCRIPT_PATH,
         "--gm_op",
         ",".join(gm_op),
         "--na_op",
@@ -88,7 +91,7 @@ def test_combination_dynamic_na_op_dm(gm_op, na_op):
 def test_fo_ol_method(fo_ol_method):
     command = [
         "python",
-        "/home/runner/work/BOAT/BOAT/examples/data_hyper_cleaning/data_hyper_cleaning.py",
+        SCRIPT_PATH,
         "--fo_op",
         fo_ol_method[0],
     ]


### PR DESCRIPTION
Fixes #28.

`examples/data_hyper_cleaning/test_data_hyper_cleaning.py` hard-codes `/home/runner/work/BOAT/BOAT/examples/data_hyper_cleaning/data_hyper_cleaning.py` (the GitHub Actions runner path) in three subprocess invocations, so the suite cannot run locally. Replace the three literals with a single `SCRIPT_PATH` resolved via `os.path.dirname(__file__)`, matching the layout of the example directory and working under both the CI runner and local checkouts.