### PR TITLE
fix(jittor): use native checkpoints in NAS example

### DIFF
--- a/examples/neural_architecture_search/neural_architecture_search.py
+++ b/examples/neural_architecture_search/neural_architecture_search.py
@@ -219,9 +219,8 @@ def main():
         )
 
         logging.info("train_acc %f , train_obj %f ", train_acc, train_obj)
-        utils.save(model, os.path.join(args.save, "weights.pt"))
         print("epoch_step_time:", epoch_time)
-        utils.save(model, os.path.join(args.save, "weights.pt"))
+        utils.save(model, os.path.join(args.save, "weights.pkl"))
     print("average_step_time", average_runtime / 3)
 
 def train(train_queue, valid_queue, model, criterion, optimizer, boat_optimizer):

--- a/examples/neural_architecture_search/utils.py
+++ b/examples/neural_architecture_search/utils.py
@@ -155,10 +155,10 @@ def count_parameters_in_MB(model):
     return np.sum(np.prod(v.shape) for name, v in model.named_parameters() if "auxiliary" not in name) / 1e6
 
 def save_checkpoint(state, is_best, save):
-    filename = os.path.join(save, "checkpoint.pth.tar")
+    filename = os.path.join(save, "checkpoint.pkl")
     jt.save(state, filename)
     if is_best:
-        best_filename = os.path.join(save, "model_best.pth.tar")
+        best_filename = os.path.join(save, "model_best.pkl")
         shutil.copyfile(filename, best_filename)
 
 def save(model, model_path):


### PR DESCRIPTION
## Summary

- save NAS checkpoints in Jittor-native `.pkl` format;
- remove the duplicate per-epoch save;
- keep checkpoint loading compatible with `jt.load`.

## Rationale

Using a `.pt` filename selects Jittor's PyTorch-format serializer, which imports PyTorch. A clean BOAT-jit environment therefore completes NAS training but fails while saving the checkpoint. Native `.pkl` serialization removes this unintended dependency.

## Validation

- syntax-checked the modified NAS Python files;
- confirmed that the epoch loop has one `weights.pkl` save and that checkpoint helper filenames use `.pkl`;
- Jittor was unavailable in the local environment, so the native save/load round-trip and CUDA NAS run were not executed;
- confirmed that the PR contains no unrelated changes.
